### PR TITLE
fix: update docker buildx version to v0.31.1

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v0.12.0
+          version: v0.31.1
 
       - name: Load tag
         run: |
@@ -142,3 +142,4 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+


### PR DESCRIPTION
Recent upgrades to GitHub Action runner images bumped the minimum Docker version to 29.1 which is no longer compatible with the outdated buildx version that was being used.

This commit bumps the version to the latest stable release v0.31.1. Release notes for this release can be found at https://github.com/docker/buildx/releases/tag/v0.31.1.